### PR TITLE
nmc/4516-files-sharing-password-disabled-after-editing-advanced-permission-without-changes-to-password

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -16,6 +16,8 @@ OC.L10N.register(
 		'With File drop, only uploading is allowed. Only you can see files and folders that have been uploaded.': 'Bei der Sammelbox ist nur das Hochladen erlaubt. Nur Sie sehen Dateien und Ordner die hochgeladen worden sind.',
 		'Advanced': 'Erweiterte',
 		'Set password': 'Passwortschutz',
+		'Password set': 'Passwort gesetzt',
+		'Change password': 'Passwort ändern',
 		'Your shares': 'Ihre Freigaben',
 		'Manage access': 'Zugriff verwalten',
 		'Send': 'Send',

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -19,6 +19,8 @@
 		"Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.": "Bitte beachten sie, dass das Weiterteilen, nur beim internen Teilen, also dem Teilen an andere MagentaCLOUD Nutzer, verfügbar ist.",
 		"Advanced settings": "Erweiterte Einstellungen",
 		"Set password": "Passwort setzen",
+		"Password set": "Passwort gesetzt",
+		"Change password": "Passwort ändern",
 		"Your shares": "Ihre Freigaben",
 		"Manage access": "Zugriff verwalten",
 		"Here you can see who has access to your file/folder.": "Hier sehen Sie wer Zugriff auf Ihre Datei/Ihren Ordner hat.",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -19,6 +19,8 @@
 		"Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.": "Bitte beachten sie, dass das Weiterteilen, nur beim internen Teilen, also dem Teilen an andere MagentaCLOUD Nutzer, verfügbar ist.",
 		"Advanced settings": "Erweiterte Einstellungen",
 		"Set password": "Passwort setzen",
+		"Password set": "Passwort gesetzt",
+		"Change password": "Passwort ändern",
 		"Your shares": "Ihre Freigaben",
 		"Manage access": "Zugriff verwalten",
 		"Here you can see who has access to your file/folder.": "Hier sehen Sie wer Zugriff auf Ihre Datei/Ihren Ordner hat.",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -18,6 +18,8 @@
 		"Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.": "Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.",
 		"Advanced settings": "Advanced settings",
 		"Set password": "Set password",
+		"Password set": "Password set",
+		"Change password": "Change password",
 		"Your shares": "Your shares",
 		"Manage access": "Manage Access",
 		"Here you can see who has access to your file/folder.": "Here you can see who has access to your file/folder.",

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -15,6 +15,8 @@ OC.L10N.register(
 		'With File drop, only uploading is allowed. Only you can see files and folders that have been uploaded.': 'With File drop, only uploading is allowed. Only you can see files and folders that have been uploaded.',
 		'Advanced': 'Advanced',
 		'Set password': 'Set password',
+		'Password set': 'Password set',
+		'Change password': 'Change password',
 		'Your shares': 'Your shares',
 		'Manage access': 'Manage Access',
 		'Send': 'Send',

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -18,6 +18,8 @@
 		"Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.": "Please note that resharing is only available for internal sharing, i.e. sharing with other MagentaCLOUD users.",
 		"Advanced settings": "Advanced settings",
 		"Set password": "Set password",
+		"Password set": "Password set",
+		"Change password": "Change password",
 		"Your shares": "Your shares",
 		"Manage access": "Manage Access",
 		"Here you can see who has access to your file/folder.": "Here you can see who has access to your file/folder.",

--- a/src/views/SharingDetailsTab.vue
+++ b/src/views/SharingDetailsTab.vue
@@ -75,10 +75,20 @@
 					{{ t('files_sharing', 'Hide download') }}
 				</NcCheckboxRadioSwitch>
 				<template v-if="isPublicShare">
-					<NcCheckboxRadioSwitch :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
-						{{ passwordHint }}
-					</NcCheckboxRadioSwitch>
-					<NcPasswordField v-if="isPasswordProtected"
+					<div class="password-row">
+						<NcCheckboxRadioSwitch :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
+							{{ passwordHint }}
+						</NcCheckboxRadioSwitch>
+						<NcButton v-if="passwordIsChecked && !showPasswordField"
+							type="tertiary"
+							@click="showPasswordField = true">
+							{{ t('nmcsharing', 'Change password') }}
+							<template #icon>
+								<PencilIcon :size="16" />
+							</template>
+						</NcButton>
+					</div>
+					<NcPasswordField v-if="isPasswordProtected && (!passwordIsChecked || showPasswordField)"
 						id="share-password-input"
 						:value="hasUnsavedPassword ? mutableShare.password : ''"
 						:error="passwordError"
@@ -215,6 +225,7 @@ export default {
 			bundledPermissions: BUNDLED_PERMISSIONS,
 			passwordError: false,
 			passwordIsChecked: false,
+			showPasswordField: false,
 			mutableShare: {
 				note: this.share.note,
 				password: this.share.password,
@@ -540,7 +551,7 @@ export default {
 		},
 		passwordHint() {
 			if (this.passwordIsChecked) {
-				return t('files_sharing', 'Replace current password')
+				return t('nmcsharing', 'Password set')
 			} else {
 				return t('nmcsharing', 'Set password')
 			}
@@ -753,6 +764,33 @@ export default {
 		}
 	}
 
+}
+
+.password-row {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.button-vue--vue-tertiary {
+		min-height: unset;
+		height: 24px;
+		padding: 0 4px;
+		font-size: 0.8rem;
+		color: var(--color-main-text);
+
+		.button-vue__wrapper {
+			flex-direction: row-reverse;
+		}
+
+		.button-vue__text {
+			font-weight: bold;
+		}
+
+		&:hover {
+			color: var(--color-primary-element);
+			background-color: transparent;
+		}
+	}
 }
 
 .checkbox-text {


### PR DESCRIPTION
**What Changed**
The password section in the Sharing Details / Advanced Settings panel has been improved to better reflect the current password state.

Before:
When a password was already set, the checkbox label showed "Replace current password" (taken from files_sharing domain)
The password input field was always visible when the checkbox was checked

After:
When a password is already set, the checkbox label now shows "Password set"
The password input field is hidden when a password is already set
A "Change password" button with a pencil icon appears next to the checkbox — clicking it reveals the input field so the user can enter a new password

**How to Test**
Open the Files app and right-click any file/folder → Sharing options
Click the share link row to open Advanced settings
Case A — No existing password:
Check the "Set password" checkbox → input field should appear
Case B — Existing password (set one first and save):
Reopen Advanced settings → label should say "Password set", input field should be hidden
Click "Change password ✏️" → input field should appear so you can enter a new one
Verify translations by switching the Nextcloud language to German (de / de_DE) and repeating the above — labels should show "Passwort gesetzt" and "Passwort ändern"

<img width="618" height="579" alt="Screenshot 2026-06-16 at 15 23 06" src="https://github.com/user-attachments/assets/bc6c084d-ed2d-4608-9d57-652040867ae0" />
